### PR TITLE
POC: Added runApp gradle task that runs front and back

### DIFF
--- a/grails-server/build.gradle
+++ b/grails-server/build.gradle
@@ -10,6 +10,19 @@ buildscript {
     }
 }
 
+plugins {
+    id "com.moowork.node" version "1.1.1"
+}
+
+node {
+    version = '6.10.3'
+    npmVersion = '3.10.10'
+    distBaseUrl = 'https://nodejs.org/dist'
+    download = true
+    workDir =  file("${project.projectDir}/../vue-app")
+    nodeModulesDir = file("${project.projectDir}/../vue-app")
+}
+
 version "0.1"
 group "grails.server"
 
@@ -60,3 +73,17 @@ bootRun {
     jvmArgs('-Dspring.output.ansi.enabled=always')
     addResources = true
 }
+
+// have an issue with stopin npm tasks https://github.com/srs/gradle-node-plugin/issues/143
+task runDev(type: NpmTask, dependsOn: 'npmInstall') {
+    workingDir = file("${project.projectDir}/../vue-app")
+   args=["run", "dev"]
+}
+
+task runApp {
+    doLast {
+        println 'App is running'
+    }
+}
+runApp.dependsOn runDev
+runApp.dependsOn bootRun

--- a/vue-app/.gitignore
+++ b/vue-app/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules/
 dist/
+node-v*/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
Adds `runApp` gradle task that run front and back - should work without npm